### PR TITLE
Remove the style for .uname

### DIFF
--- a/gap-analysis/language-matrix-data/matrix.css
+++ b/gap-analysis/language-matrix-data/matrix.css
@@ -91,11 +91,6 @@ samp, kbd {
 	font-family: Consolas, "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", Monaco, "Courier New", monospace; 
     font-size: 100%; 
     }
-.uname {
-	text-transform: uppercase;
-	font-size: 85%;
-	letter-spacing:0.03em;
-	}
 
 
 /* HEAD BOILERPLATE */

--- a/gap-analysis/matrix.css
+++ b/gap-analysis/matrix.css
@@ -91,11 +91,6 @@ samp, kbd {
 	font-family: Consolas, "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", Monaco, "Courier New", monospace; 
     font-size: 100%; 
     }
-.uname {
-	text-transform: uppercase;
-	font-size: 85%;
-	letter-spacing:0.03em;
-	}
 
 
 /* HEAD BOILERPLATE */

--- a/index-data/local.css
+++ b/index-data/local.css
@@ -85,11 +85,6 @@ samp, kbd {
 	font-family: Consolas, "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", Monaco, "Courier New", NoToFu, monospace; 
     font-size: 100%; 
     }
-.uname {
-	text-transform: uppercase;
-	font-size: 85%;
-	letter-spacing:0.03em;
-	}
 
 
 


### PR DESCRIPTION
Since it's in tr-design now: https://github.com/w3c/tr-design/pull/323